### PR TITLE
Add script for handling blocklists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tmp/
 
 # Created by https://www.gitignore.io/api/macos,linux,windows,sublimetext,intellij+all,archlinuxpackages
 # Edit at https://www.gitignore.io/?templates=macos,linux,windows,sublimetext,intellij+all,archlinuxpackages

--- a/list_urls/pihole.urls
+++ b/list_urls/pihole.urls
@@ -1,6 +1,6 @@
 https://1hos.cf/
 https://dbl.oisd.nl/
-https://github.com/rblaine95/NSABlocklist/raw/master/HOSTS
+https://github.com/CHEF-KOCH/NSABlocklist/raw/master/HOSTS
 https://hosts-file.net/ad_servers.txt
 https://hosts-file.net/download/hosts.txt
 https://mirror1.malwaredomains.com/files/justdomains

--- a/script.sh
+++ b/script.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+U=""
+
+###
+# Get blocklist urls from firebog
+# Copy pihole urls to tmp file
+# Sort tmp file into $U
+# Delete tmp file
+###
+get_urls(){
+  curl -s https://v.firebog.net/hosts/lists.php?type=nocross -o urls.tmp
+  cat list_urls/pihole.urls >> urls.tmp
+  U=$(sort -u urls.tmp)
+  rm -f urls.tmp
+}
+
+###
+# For each URL in $U
+# Download list into single file
+###
+get_lists(){
+  for u in $U; do
+    printf "==============================\n"
+    printf "Downloading $u \n"
+    printf "==============================\n"
+    wget $u -O- >> list
+  done
+}
+
+###
+# I'm a little ashamed that I copy-pasted this from pihole -g
+# This little function here will:
+# Remove all comments, trailing '/', and IP addresses
+# Returning only the domains
+# Seriously, full credit for this function right here goes to the guys and gals
+# over at Pi-Hole
+# https://github.com/pi-hole/pi-hole/blob/master/gravity.sh#L333
+###
+parse_domains(){
+  local source="${1}" destination="${2}"
+  
+  < ${source} awk -F '#' '{print $1}' | \
+  awk -F '/' '{print $1}' | \
+  awk '($1 !~ /^#/) { if (NF>1) {print $2} else {print $1}}' | \
+  sed -nr -e 's/\.{2,}/./g' -e '/\./p' >  ${destination}
+}
+
+###
+# Sort and extract unique domains
+###
+sort_masterlist(){
+  printf "=== Sorting and extracting unique domains ===\n"
+  sort -u list.domains > list.sorted
+}
+
+main(){
+  get_urls
+  get_lists
+  parse_domains list list.domains
+  sort_masterlist
+}
+
+main


### PR DESCRIPTION
* Get `firebog_nocross` blocklist URLs
* Remove duplicate blocklists between Pihole and Firebog
* Loop through the URLs and download all the blocklists into a single
temp file
* Parse the temp file into a new file that only contains domains (thanks
pi-hole)
* Sort and extract all unique domains from the parsed file

Fixes #3 

- [x] Run through the lists of URLs in `list_urls` directory
- [x] Download the lists into a single text file
- [x] Remove comments from the master-list
- [x] Remove IPs from master-list (so that it's domains only)
- [x] Remove duplicate domains from master-list
- [x] Download the firebog list from [firebog](https://v.firebog.net/hosts/lists.php?type=nocross) instead of hard-coding it
- [x] Remove duplicate URLs between the firebog list and the Pihole list